### PR TITLE
chore: add AI PR review GitHub Actions workflow

### DIFF
--- a/.claude/skills/automation-ideas/SKILL.md
+++ b/.claude/skills/automation-ideas/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: automation-ideas
+description: Brainstorm at least 10 automation ideas for this project across three tiers (plain non-AI automation, AI-assisted SDLC support, AI agentic loops), then create one GitHub issue per idea the user picks. Invoke when the user says "automation ideas", "how could we automate this project", "suggest some automations", or "/automation-ideas".
+allowed-tools: mcp__github__create_issue mcp__github__list_issues
+---
+
+```!
+echo "REPO: $(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')"
+```
+
+## Step 1 — Generate ideas
+
+Produce **at least 10 ideas total**, spread across three tiers. Ground every idea in something real about this repo — its Aspire backend, Angular/Nx frontend, RabbitMQ/SignalR, CI workflows, bounded contexts — not generic boilerplate. Skim `.github/workflows/`, `CLAUDE.md`, and recent PR/issue activity first if useful context is missing.
+
+### Tier 1 — Plain automation (no AI, deterministic, cheap to build)
+
+Few-shot examples (calibrate scope and tone — this specific, not vaguer):
+
+- **PR-open Slack/Discord ping** — GitHub Action posts to a webhook when a PR opens or goes ready-for-review, so nobody has to poll GitHub.
+- **Stale-branch reminder** — weekly workflow comments on PRs with no activity for 14+ days and pings the author.
+- **Path-based auto-labeler** — label PRs `frontend`/`backend`/`infra` automatically based on which top-level directory changed.
+- **Migration-file guard** — CI check that fails a PR if it hand-edits a file under `*.Persistence.Context/Migrations/`.
+- **Dependency update bot** — Renovate/Dependabot configured for `client/package.json` and the `.csproj` files, grouped by ecosystem.
+
+### Tier 2 — AI-assisted SDLC support (human-triggered, AI does the work)
+
+Few-shot examples:
+
+- **AI PR description filler** — on PR open with an empty body, a bot generates a summary from the diff and posts it as a suggested description.
+- **AI flaky-test triage** — when CI fails, a workflow asks a model to read the failure log and post a comment guessing root cause + which file to look at.
+- **AI changelog drafter** — on release tag push, generate `CHANGELOG.md` entry from merged PR titles since the last tag.
+- **AI code-review second pass** — after human approval, run `/code-review` in CI and post findings as a non-blocking comment.
+
+### Tier 3 — AI agentic loops (triggered or scheduled, multi-step, low human involvement)
+
+Few-shot examples:
+
+- **Nightly dead-code sweep** — scheduled agent scans for unused Angular components/exports and unreferenced .NET classes, files one issue per cluster found (not one per file).
+- **CI-failure auto-fix loop** — on a failed build on a non-protected branch, an agent reproduces the failure, attempts a minimal fix, and opens a draft PR against the original branch for human review.
+- **Issue-to-spec agent** — on issue label `needs-spec`, automatically invoke the `spec` skill and post a link to the generated doc as a comment.
+- **Dependency-bump verifier loop** — when Dependabot opens a PR, an agent checks it out, runs the affected test suites, and either approves or comments with the failure.
+
+### Output format for Step 1
+
+Present ideas compactly — **do not** write the detailed version yet:
+
+```
+### Tier 1 — Plain automation
+1. **Title** — one-sentence hook.
+2. ...
+
+### Tier 2 — AI-assisted SDLC support
+...
+
+### Tier 3 — AI agentic loops
+...
+```
+
+Number ideas sequentially across all tiers (1–10+) so they're easy to reference.
+
+---
+
+## Step 2 — Get the user's picks
+
+Use `AskUserQuestion` (multiSelect) or a plain follow-up asking which numbered ideas to turn into issues. Do not create any issue before the user has picked.
+
+---
+
+## Step 3 — Create one GitHub issue per selected idea
+
+For each idea the user picked, expand the one-liner into a detailed issue body — the compact pitch from Step 1 is not enough for an issue. Use this structure:
+
+```markdown
+## Problem / Motivation
+
+[Why this is worth automating — what manual toil or risk it removes, grounded in this repo's actual workflow.]
+
+## Proposed Approach
+
+[Concrete mechanism: which GitHub Action/trigger, which script or model call, what it reads and where it writes/posts. Name real paths — e.g. `.github/workflows/`, `server/src/Hiscary.<Ctx>`, `client/apps/hiscaries-client` — where applicable.]
+
+## Tier
+
+[Tier 1 — Plain automation | Tier 2 — AI-assisted SDLC support | Tier 3 — AI agentic loop]
+
+## Acceptance Criteria
+
+- [ ] {specific, testable outcome}
+- [ ] {specific, testable outcome}
+```
+
+Call `mcp__github__create_issue` once per idea:
+- `owner`/`repo`: parsed from `REPO` above
+- `title`: the idea's title (no numbering prefix)
+- `body`: the expanded body above
+- `labels`: `["automation-idea"]` plus one of `["tier-1-automation", "tier-2-ai-assist", "tier-3-agentic-loop"]` matching the tier
+
+If a label doesn't exist yet, `create_issue` will still apply it as text — GitHub auto-creates unknown labels on issue creation via the API in most cases; if it errors, retry without that label and note it in the report.
+
+---
+
+## Step 4 — Report
+
+List, per created issue: title, tier, and issue URL. Do not restate the full body.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: security-audit
+description: Run a full security audit of this repo — secrets/tokens exposed in the codebase and git history, OWASP Top 10 concerns across the .NET backend and Angular frontend, dependency vulnerabilities, and CI/CD misconfiguration — then create one GitHub issue per confirmed finding automatically. Invoke when the user says "security audit", "audit security", "check for exposed secrets", "run a security scan", or "/security-audit".
+allowed-tools: Bash(git log *) Bash(git grep *) Grep Read Bash(npm audit *) Bash(dotnet list package --vulnerable *) mcp__github__create_issue mcp__github__list_issues
+---
+
+```!
+echo "REPO: $(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')"
+```
+
+## Hard safety rule — read this first
+
+**Never paste an actual discovered secret's plaintext value into chat output or an issue body.** This repo is public — an issue containing a live token is itself a leak. Redact to the first 4–6 characters plus `***` (e.g. `ghp_KxzT***`), mark the finding **Critical**, and lead the remediation with "rotate this credential immediately," not just "remove it."
+
+---
+
+## Step 1 — Run the checks
+
+Work through all four categories below. Only report **confirmed** findings — something you actually located at a specific path/line or actually ran and observed — not speculative "you should probably check X" items.
+
+### A. Secrets & credentials exposed to git
+
+- Grep the **working tree** for key/token/password/connection-string patterns in `appsettings*.json`, `launchSettings.json`, docker/compose files, `.env*`, and any `*.config` files: patterns like `password\s*=`, `ConnectionString`, `api[_-]?key`, `secret`, `ghp_`, `github_pat_`, `AKIA[0-9A-Z]{16}`, `-----BEGIN.*PRIVATE KEY-----`.
+- Separately search **git history**, not just the current tree — a secret removed in a later commit still lives in history: `git log -p --all -S'<pattern>' -- <suspicious-path>` or `git log --all --oneline -- '**/appsettings*.json'` followed by inspecting diffs of past versions.
+- Check `.gitignore` actually covers `.env*`, `*.pfx`, `*.pem`, and any `appsettings.*.json` overrides beyond the base file.
+- Check GitHub Actions workflows (`.github/workflows/*.yml`) for secrets echoed to logs (e.g. `run: echo ${{ secrets.X }}`) or unsafe `pull_request_target` combined with checkout of untrusted PR code.
+
+### B. OWASP Top 10 (2021), mapped to this stack
+
+- **A01 Broken Access Control** — API controllers missing `[Authorize]`; JWT validation config in `Hiscary.Shared.Jwt`; CORS policy in the AppHost/gateway.
+- **A02 Cryptographic Failures** — hardcoded salts/keys committed to config (e.g. a static `StoredSalt` in `appsettings.json` instead of a per-user salt or secret-manager value), weak hashing, missing TLS enforcement.
+- **A03 Injection** — raw SQL or string-concatenated EF Core queries; unsanitized `[innerHTML]` bindings or `bypassSecurityTrust*` calls in Angular templates without a sanitization step.
+- **A04 Insecure Design** — missing rate limiting on auth/login endpoints; predictable password-reset flow.
+- **A05 Security Misconfiguration** — wildcard (`*`) CORS origins, Swagger/OpenAPI exposed without gating in production, default/blank infra credentials in `Hiscary.AppHost/Program.cs`.
+- **A06 Vulnerable & Outdated Components** — see dependency scan (C) below.
+- **A07 Identification & Authentication Failures** — weak password policy, missing refresh-token rotation/revocation, long-lived or non-expiring JWTs.
+- **A08 Software & Data Integrity Failures** — unpinned third-party GitHub Actions (using `@main`/`@master` instead of a version tag or SHA), risky `postinstall`/build scripts.
+- **A09 Security Logging & Monitoring Failures** — auth failures and privilege-relevant actions not logged anywhere observable.
+- **A10 SSRF** — any server-side code that fetches a URL derived from user input (check `Hiscary.Media.DocumentTools.PuppeteerSharp` and similar document-rendering/fetch paths).
+
+### C. Dependency vulnerabilities
+
+- `cd client && npm audit --json` — parse for `high`/`critical` advisories.
+- `cd server/src && dotnet list Hiscary.sln package --vulnerable --include-transitive` — parse for reported vulnerable packages.
+
+### D. CI/CD
+
+- Workflow permission scopes wider than needed (e.g. `permissions: write-all`).
+- Third-party actions pinned to a mutable ref instead of a tag/SHA.
+- Secrets available to workflows triggered by `pull_request` from forks.
+
+---
+
+## Step 2 — Few-shot calibration (finding format, not exhaustive)
+
+Use these as the bar for specificity and severity — findings should read like this, anchored to real paths, not generic advice:
+
+> **Title:** Hardcoded bcrypt salt committed in `appsettings.json`
+> **Severity:** Medium
+> **OWASP:** A02 — Cryptographic Failures
+> **Evidence:** `server/src/appsettings.json` — `SaltSettings.StoredSalt` is a static value committed to source control and shared across all environments.
+> **Remediation:** Move to a per-environment secret (user-secrets locally, a secret manager or Aspire parameter in deployed environments) and rotate the current value since it has been exposed via version control.
+
+> **Title:** Unsanitized `[innerHTML]` binding in story reader
+> **Severity:** High
+> **OWASP:** A03 — Injection
+> **Evidence:** `client/apps/hiscaries-client/src/app/stories/read-story-content/read-story-content.component.html:168` binds `[innerHTML]="currentPageContent"` directly; confirm whether `currentPageContent` is sanitized upstream (e.g. via Angular's `DomSanitizer`) or could contain user/author-supplied HTML.
+> **Remediation:** Sanitize with Angular's built-in sanitizer or a vetted HTML-sanitization library before binding; add a regression test asserting script tags are stripped.
+
+> **Title:** Live GitHub token committed to a tracked file
+> **Severity:** Critical
+> **OWASP:** N/A — Secrets exposure
+> **Evidence:** `<path>:<line>` — a token matching `ghp_***` (redacted) is present in a tracked file / git history.
+> **Remediation:** Rotate the token immediately at github.com/settings/tokens, then remove it from history (`git filter-repo` or BFG) since a simple new commit does not remove it from history.
+
+---
+
+## Step 3 — De-dupe against previous runs
+
+Call `mcp__github__list_issues` with `labels: ["security-audit"]`, `state: "all"`. Skip creating an issue whose title matches (or near-matches) one already present, open or closed.
+
+---
+
+## Step 4 — Create one issue per confirmed finding
+
+For each confirmed, non-duplicate finding, call `mcp__github__create_issue`:
+
+- `title`: short and specific (as in Step 2's examples)
+- `body`:
+  ```markdown
+  ## Finding
+
+  [What was found and why it matters, in this repo's context.]
+
+  ## Evidence
+
+  [Exact path:line. If a secret value, redact per the hard safety rule above.]
+
+  ## OWASP Category
+
+  [e.g. A03 — Injection, or "N/A — Secrets exposure"]
+
+  ## Severity
+
+  [Critical | High | Medium | Low]
+
+  ## Remediation
+
+  [Concrete next step — name the actual fix, not "review this."]
+  ```
+- `labels`: `["security-audit", "severity-<critical|high|medium|low>"]`
+
+This runs automatically as part of invoking this skill — do not pause to ask the user which findings to file (unlike `automation-ideas`, every confirmed finding here gets an issue).
+
+---
+
+## Step 5 — Report
+
+List each created issue: title, severity, URL. Do not restate evidence or secret values in the summary — link to the issue instead.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -75,9 +75,12 @@ gh pr create \
   --label "ai"
 ```
 
-If the GitHub MCP server is connected (`mcp__github__*` tools are available):
-- Use `mcp__github__list_issues` to check if any open issue matches the feature — if so, link it in the PR body with `Closes #<N>`.
-- Use `mcp__github__create_pull_request` as an alternative to `gh pr create` if the CLI is not available (note: add assignee and label via `gh pr edit <url> --add-assignee @me --add-label "ai"` after creation if using MCP).
+Create the PR using this priority order:
+
+1. **MCP first** — use `mcp__github__create_pull_request` (owner/repo parsed from `git remote get-url origin`). Then add assignee and label via `gh pr edit <url> --add-assignee @me --add-label "ai"` if `gh` is available.
+2. **gh fallback** — only if MCP fails or is unavailable: use `gh pr create --title ... --body ... --base master --assignee @me --label "ai"`.
+
+Also use `mcp__github__list_issues` to check for a matching open issue and append `Closes #<N>` to the PR body if found.
 
 ### 7. Report
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -60,16 +60,24 @@ If `$title` was provided as an argument, use it as the PR title. Otherwise deriv
 
 ### 6. Create the PR
 
+Ensure the "ai" label exists before creating the PR:
+```
+gh label create "ai" --color "0075ca" --description "AI-assisted change" 2>/dev/null || true
+```
+
+Create the PR with assignee and label:
 ```
 gh pr create \
   --title "<title>" \
   --body "<body from step 5>" \
-  --base master
+  --base master \
+  --assignee @me \
+  --label "ai"
 ```
 
 If the GitHub MCP server is connected (`mcp__github__*` tools are available):
 - Use `mcp__github__list_issues` to check if any open issue matches the feature — if so, link it in the PR body with `Closes #<N>`.
-- Use `mcp__github__create_pull_request` as an alternative to `gh pr create` if the CLI is not available.
+- Use `mcp__github__create_pull_request` as an alternative to `gh pr create` if the CLI is not available (note: add assignee and label via `gh pr edit <url> --add-assignee @me --add-label "ai"` after creation if using MCP).
 
 ### 7. Report
 

--- a/.github/prompts/pr-review.md
+++ b/.github/prompts/pr-review.md
@@ -1,0 +1,128 @@
+You are a strict code reviewer for the Hiscaries platform — a .NET 9 / Aspire DDD+CQRS backend with an Angular 18 NgRx frontend.
+
+Your job: find defects. Not style issues. Not things to praise. Defects only.
+
+## What you MUST NOT do
+
+- Do not comment on what is correct, well-written, or good practice.
+- Do not summarise changes.
+- Do not suggest refactors unless they prevent a concrete bug.
+- Do not flag naming, formatting, or whitespace.
+- Do not output anything except the JSON object defined by your schema.
+- Do not emit a finding if you are not confident it is a real problem.
+
+## What you review
+
+You look for: security vulnerabilities, logical bugs, broken contracts, dangerous async patterns, architecture violations, and resource leaks. Nothing else.
+
+---
+
+## Severity: CRITICAL
+
+Block merge. These introduce security holes, data corruption, or service crashes that affect production users.
+
+**Criteria — flag as critical if the code:**
+- Concatenates user input into a raw SQL string or shell command
+- Embeds a secret, credential, connection string, or API key as a string literal in source code
+- Applies `[AllowAnonymous]` or omits `[Authorize]` on an endpoint that reads or writes user-owned or admin-only data
+- Validates a JWT by checking only its presence, not its signature or expiry
+- Performs a non-atomic read-then-write on shared state without a database transaction, where interleaving writes would produce corrupt data
+- Returns an unhandled exception's stack trace or internal message directly in an HTTP response body
+- Uses MD5 or SHA1 for password hashing, or uses a hardcoded IV/key for encryption
+
+**Few-shot examples:**
+
+Finding 1
+- file: server/src/Hiscary.UserAccounts.Api.Rest/Controllers/AuthController.cs
+- line: 58
+- title: SQL injection via string interpolation
+- body: `$"SELECT * FROM Users WHERE email = '{email}'"` concatenates raw user input into SQL. An attacker can inject arbitrary SQL. Replace with a parameterised EF Core query: `context.Users.FirstOrDefaultAsync(u => u.Email == email)`.
+
+Finding 2
+- file: server/src/Hiscary.Stories.Api.Rest/Controllers/StoryController.cs
+- line: 12
+- title: Missing [Authorize] on endpoint that modifies user data
+- body: `DeleteStory` has no `[Authorize]` attribute. Any unauthenticated request can delete any story. Add `[Authorize]` and verify the requesting user owns the story before deleting.
+
+Finding 3
+- file: server/src/Hiscary.Shared.Jwt/JwtService.cs
+- line: 34
+- title: Hardcoded JWT signing key
+- body: The signing key `"super_secret_key_hiscaries"` is a string literal. If the source code leaks, all tokens can be forged. Load the key from `IConfiguration` / environment variable and rotate it without a redeploy.
+
+---
+
+## Severity: HIGH
+
+Should block merge unless explicitly accepted by the team. These cause wrong behaviour, data loss, or service degradation under real load or edge cases.
+
+**Criteria — flag as high if the code:**
+- Calls an external I/O operation (database, HTTP, RabbitMQ, Azure Blob) without a try/catch or awaited error path, where an exception would crash the host process or leave the operation silently incomplete
+- Returns HTTP 500 for a predictable business error that should be 400, 404, or 409 (e.g., entity not found, duplicate key, validation failure)
+- Queries a collection from the database and then queries inside a loop over that collection (N+1 pattern)
+- Places domain or application logic (computation, validation, business rules) directly in a `.Api.Rest` controller method
+- Has an NgRx effect that handles an error with `catchError` but dispatches no `*Failure` action, leaving the UI in a perpetual loading state
+- Uses `.Result`, `.Wait()`, or `.GetAwaiter().GetResult()` on a `Task` inside an ASP.NET Core request handler (deadlocks under the sync context)
+- Accesses an EF Core navigation property that is not `.Include()`-d, resulting in a null reference at runtime
+- Instantiates `DbContext`, `HttpClient`, or a stream outside of dependency injection and does not call `.Dispose()`
+
+**Few-shot examples:**
+
+Finding 1
+- file: server/src/Hiscary.Stories.Application.Write/Commands/PublishStoryHandler.cs
+- line: 44
+- title: Missing not-found check — EF throws InvalidOperationException mapped as 500
+- body: `context.Stories.Where(s => s.Id == id).First()` throws `InvalidOperationException` when no match exists. The global exception middleware returns this as HTTP 500. Use `FirstOrDefaultAsync` and return a typed `NotFoundException` that your middleware maps to 404.
+
+Finding 2
+- file: server/src/Hiscary.Notifications.EventHandlers/StoryPublishedHandler.cs
+- line: 67
+- title: Uncaught exception on RabbitMQ publish crashes the worker
+- body: `_channel.BasicPublish(...)` is called with no try/catch. A transient broker failure throws `AlreadyClosedException`, which is unhandled and terminates the `IHostedService` processing loop. Wrap in try/catch and implement a retry or dead-letter strategy.
+
+Finding 3
+- file: client/apps/hiscaries-client/src/app/stories/store/story.effects.ts
+- line: 89
+- title: NgRx effect swallows error — UI spinner never resolves
+- body: The `catchError` block returns `EMPTY` without dispatching a failure action. When the API call fails, `isLoading` remains `true` in the store permanently. Dispatch `loadStoriesFailure` and handle it in the reducer to reset loading state.
+
+---
+
+## Severity: MEDIUM
+
+Fix before merge where possible; may be accepted with a justification comment. These do not cause immediate failures but will cause bugs when the codebase grows or load increases.
+
+**Criteria — flag as medium if the code:**
+- Has a `catch (Exception)` block that logs nothing and rethrows nothing — the error disappears silently
+- Accepts a `CancellationToken` parameter but does not pass it to any awaited call inside the method
+- Puts an HTTP call or subscription in an Angular component's `constructor` instead of `ngOnInit`
+- Imports across Angular domain boundaries using a relative path (`../../shared/...`) instead of the configured alias (`@shared/...`)
+- Hardcodes a string that belongs in configuration (base URLs, feature flags, thresholds) with no constant or injection point
+- Hand-edits a generated EF Core migration file (adds or removes lines after `dotnet ef migrations add` ran)
+- Uses `any` type in TypeScript where the actual type is knowable from the context
+
+**Few-shot examples:**
+
+Finding 1
+- file: server/src/Hiscary.Media.Application.Write/Commands/UploadImageHandler.cs
+- line: 103
+- title: CancellationToken accepted but not forwarded
+- body: The method signature accepts `CancellationToken cancellationToken` but every `await` call inside — `SaveAsync`, `UploadAsync`, `context.SaveChangesAsync()` — omits the token. Long uploads cannot be cancelled, holding connections open after the client disconnects.
+
+Finding 2
+- file: client/apps/hiscaries-client/src/app/users/home/home.component.ts
+- line: 18
+- title: HTTP call in constructor fires before inputs are resolved
+- body: `this.userService.getProfile().subscribe(...)` runs in the constructor. Angular does not guarantee `@Input()` values are set at construction time. Move to `ngOnInit`.
+
+Finding 3
+- file: client/apps/hiscaries-client/src/app/stories/story-list/story-list.component.ts
+- line: 5
+- title: Cross-domain import uses relative path instead of alias
+- body: `import { AuthService } from '../../shared/auth/auth.service'` crosses the stories/shared domain boundary with a relative path. Use `@shared/auth/auth.service` as configured in `tsconfig.base.json` to prevent path drift when files move.
+
+---
+
+## Output
+
+Return only the JSON object matching your schema. If you find no issues, return `{ "findings": [] }`. Do not write any text outside the JSON object.

--- a/.github/prompts/review-schema.json
+++ b/.github/prompts/review-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["findings"],
+  "additionalProperties": false,
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "file", "line", "title", "body"],
+        "additionalProperties": false,
+        "properties": {
+          "severity": { "type": "string", "enum": ["critical", "high", "medium"] },
+          "file":     { "type": "string", "description": "Repo-relative file path, e.g. server/src/Hiscary.Stories.Api.Rest/Controllers/StoryController.cs" },
+          "line":     { "type": "integer", "minimum": 1, "description": "Line number in the file (not the diff position)" },
+          "title":    { "type": "string", "maxLength": 120 },
+          "body":     { "type": "string", "description": "Problem + required fix. No praise. No summary of what is correct." }
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/check-unresolved.py
+++ b/.github/scripts/check-unresolved.py
@@ -7,54 +7,13 @@ Claude call, until those threads are resolved.
 
 Usage: check-unresolved.py --repo owner/repo --pr 42
 """
-import argparse, json, subprocess, sys
+import argparse, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from review_threads import fetch_review_threads, bot_authored
 
 # Must match SEVERITY_EMOJI["critical"] / ["high"] in post-review.py
 BLOCKING_PREFIXES = ("🔴", "🟠")
-
-QUERY = """
-query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $pr) {
-      reviewThreads(first: 100, after: $after) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          isResolved
-          comments(first: 1) {
-            nodes { body author { login } }
-          }
-        }
-      }
-    }
-  }
-}
-"""
-
-
-def fetch_threads(owner, repo, pr):
-    threads = []
-    after = None
-    while True:
-        args = [
-            "gh", "api", "graphql",
-            "-f", f"query={QUERY}",
-            "-f", f"owner={owner}",
-            "-f", f"repo={repo}",
-            "-F", f"pr={pr}",
-        ]
-        args += ["-f", f"after={after}"] if after else ["-F", "after=null"]
-
-        result = subprocess.run(args, capture_output=True, text=True)
-        if result.returncode != 0:
-            print(result.stderr, file=sys.stderr)
-            sys.exit(1)
-
-        page = json.loads(result.stdout)["data"]["repository"]["pullRequest"]["reviewThreads"]
-        threads.extend(page["nodes"])
-        if not page["pageInfo"]["hasNextPage"]:
-            break
-        after = page["pageInfo"]["endCursor"]
-    return threads
 
 
 def main():
@@ -64,20 +23,13 @@ def main():
     args = parser.parse_args()
 
     owner, repo = args.repo.split("/", 1)
-    threads = fetch_threads(owner, repo, args.pr)
+    threads = fetch_review_threads(owner, repo, args.pr)
 
     blocking = []
     for thread in threads:
-        if thread["isResolved"]:
+        if thread["isResolved"] or not bot_authored(thread):
             continue
-        comments = thread["comments"]["nodes"]
-        if not comments:
-            continue
-        first = comments[0]
-        author = (first.get("author") or {}).get("login", "")
-        body = first.get("body", "")
-        if "github-actions" not in author:
-            continue
+        body = thread["comments"]["nodes"][0]["body"]
         if body.startswith(BLOCKING_PREFIXES):
             blocking.append(body.splitlines()[0])
 

--- a/.github/scripts/check-unresolved.py
+++ b/.github/scripts/check-unresolved.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Fails if the PR has unresolved review threads left over from a previous AI
+review run at critical or high severity. Runs before the new Claude analysis
+so a PR with outstanding blocking feedback fails fast, without spending a
+Claude call, until those threads are resolved.
+
+Usage: check-unresolved.py --repo owner/repo --pr 42
+"""
+import argparse, json, subprocess, sys
+
+# Must match SEVERITY_EMOJI["critical"] / ["high"] in post-review.py
+BLOCKING_PREFIXES = ("🔴", "🟠")
+
+QUERY = """
+query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          comments(first: 1) {
+            nodes { body author { login } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_threads(owner, repo, pr):
+    threads = []
+    after = None
+    while True:
+        args = [
+            "gh", "api", "graphql",
+            "-f", f"query={QUERY}",
+            "-f", f"owner={owner}",
+            "-f", f"repo={repo}",
+            "-F", f"pr={pr}",
+        ]
+        args += ["-f", f"after={after}"] if after else ["-F", "after=null"]
+
+        result = subprocess.run(args, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            sys.exit(1)
+
+        page = json.loads(result.stdout)["data"]["repository"]["pullRequest"]["reviewThreads"]
+        threads.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        after = page["pageInfo"]["endCursor"]
+    return threads
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", required=True, type=int)
+    args = parser.parse_args()
+
+    owner, repo = args.repo.split("/", 1)
+    threads = fetch_threads(owner, repo, args.pr)
+
+    blocking = []
+    for thread in threads:
+        if thread["isResolved"]:
+            continue
+        comments = thread["comments"]["nodes"]
+        if not comments:
+            continue
+        first = comments[0]
+        author = (first.get("author") or {}).get("login", "")
+        body = first.get("body", "")
+        if "github-actions" not in author:
+            continue
+        if body.startswith(BLOCKING_PREFIXES):
+            blocking.append(body.splitlines()[0])
+
+    if blocking:
+        print(f"::error::{len(blocking)} unresolved critical/high finding(s) from a previous AI review "
+              f"must be resolved (or marked resolved) before this PR can proceed:")
+        for line in blocking:
+            print(f"  - {line}")
+        sys.exit(1)
+
+    print("No unresolved critical/high AI review findings from previous runs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/post-review.py
+++ b/.github/scripts/post-review.py
@@ -3,7 +3,10 @@
 Reads Claude's findings JSON and posts a single PR review with inline comments.
 Usage: post-review.py --findings /tmp/review.json --diff /tmp/pr.diff --repo owner/repo --pr 42
 """
-import argparse, json, re, subprocess, sys
+import argparse, json, os, re, subprocess, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from review_threads import fetch_review_threads, bot_authored
 
 SEVERITY_EMOJI = {"critical": "🔴", "high": "🟠", "medium": "🟡"}
 
@@ -64,8 +67,26 @@ def main():
     with open(args.diff) as f:
         commentable = parse_commentable_lines(f.read())
 
+    owner, repo = args.repo.split("/", 1)
+
+    # Skip findings already sitting in an unresolved thread at the same
+    # file:line — otherwise every push re-posts the same finding as a new
+    # duplicate comment instead of leaving the existing one to be resolved.
+    already_flagged = {
+        (t["path"], t["line"])
+        for t in fetch_review_threads(owner, repo, args.pr)
+        if not t["isResolved"] and bot_authored(t) and t.get("line") is not None
+    }
+
+    new_findings = [f for f in findings if (f["file"], f["line"]) not in already_flagged]
+    duplicate_count = len(findings) - len(new_findings)
+
+    if not new_findings:
+        print(f"No new findings — {duplicate_count} already flagged in an unresolved thread.")
+        return
+
     inline_comments, folded = [], []
-    for finding in findings:
+    for finding in new_findings:
         if finding["line"] in commentable.get(finding["file"], set()):
             inline_comments.append({"path": finding["file"], "line": finding["line"], "body": format_finding(finding)})
         else:
@@ -82,6 +103,8 @@ def main():
         summary_lines.append(f"🟠 **{counts['high']} high**")
     if counts["medium"]:
         summary_lines.append(f"🟡 {counts['medium']} medium")
+    if duplicate_count:
+        summary_lines.append(f"\n_{duplicate_count} finding(s) already flagged in an earlier unresolved comment — skipped._")
 
     if folded:
         summary_lines.append(
@@ -93,7 +116,6 @@ def main():
 
     event = "REQUEST_CHANGES" if (counts["critical"] or counts["high"]) else "COMMENT"
 
-    owner, repo = args.repo.split("/", 1)
     payload = json.dumps({"body": "\n".join(summary_lines), "event": event, "comments": inline_comments})
 
     result = subprocess.run(

--- a/.github/scripts/post-review.py
+++ b/.github/scripts/post-review.py
@@ -59,6 +59,11 @@ def main():
 
     print(f"Posted review: {event} with {len(findings)} finding(s).")
 
+    if counts["critical"] or counts["high"]:
+        print(f"::error::{counts['critical']} critical, {counts['high']} high severity finding(s) "
+              f"must be resolved before this PR can be merged.", file=sys.stderr)
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/post-review.py
+++ b/.github/scripts/post-review.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Reads Claude's findings JSON and posts a single PR review with inline comments.
+Usage: post-review.py --findings /tmp/review.json --repo owner/repo --pr 42
+"""
+import argparse, json, subprocess, sys
+
+SEVERITY_EMOJI = {"critical": "🔴", "high": "🟠", "medium": "🟡"}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--findings", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", required=True, type=int)
+    args = parser.parse_args()
+
+    with open(args.findings) as f:
+        data = json.load(f)
+
+    findings = data.get("findings", [])
+    if not findings:
+        print("No findings — skipping review comment.")
+        return
+
+    comments = []
+    for finding in findings:
+        emoji = SEVERITY_EMOJI.get(finding["severity"], "⚪")
+        body = f"{emoji} **[{finding['severity'].upper()}] {finding['title']}**\n\n{finding['body']}"
+        comments.append({"path": finding["file"], "line": finding["line"], "body": body})
+
+    counts = {"critical": 0, "high": 0, "medium": 0}
+    for finding in findings:
+        counts[finding["severity"]] += 1
+
+    summary_lines = ["## AI Code Review\n"]
+    if counts["critical"]:
+        summary_lines.append(f"🔴 **{counts['critical']} critical**")
+    if counts["high"]:
+        summary_lines.append(f"🟠 **{counts['high']} high**")
+    if counts["medium"]:
+        summary_lines.append(f"🟡 {counts['medium']} medium")
+    review_body = "\n".join(summary_lines)
+
+    event = "REQUEST_CHANGES" if (counts["critical"] or counts["high"]) else "COMMENT"
+
+    owner, repo = args.repo.split("/", 1)
+    payload = json.dumps({"body": review_body, "event": event, "comments": comments})
+
+    result = subprocess.run(
+        ["gh", "api", f"/repos/{owner}/{repo}/pulls/{args.pr}/reviews",
+         "--method", "POST", "--input", "-"],
+        input=payload, text=True, capture_output=True
+    )
+
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Posted review: {event} with {len(findings)} finding(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/post-review.py
+++ b/.github/scripts/post-review.py
@@ -1,33 +1,75 @@
 #!/usr/bin/env python3
 """
 Reads Claude's findings JSON and posts a single PR review with inline comments.
-Usage: post-review.py --findings /tmp/review.json --repo owner/repo --pr 42
+Usage: post-review.py --findings /tmp/review.json --diff /tmp/pr.diff --repo owner/repo --pr 42
 """
-import argparse, json, subprocess, sys
+import argparse, json, re, subprocess, sys
 
 SEVERITY_EMOJI = {"critical": "🔴", "high": "🟠", "medium": "🟡"}
+
+HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def parse_commentable_lines(diff_text):
+    """GitHub only accepts inline review comments on lines visible in the diff
+    (added or context lines within a hunk) — anything else gets the whole
+    review batch rejected with HTTP 422. Build the set of (file, line) pairs
+    that are actually safe to comment on, per the new-file line numbering
+    Claude is instructed to report."""
+    commentable = {}
+    current_file = None
+    new_line = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:].strip()
+            current_file = path[2:] if path.startswith("b/") else (None if path == "/dev/null" else path)
+            new_line = None
+            continue
+        if line.startswith("@@"):
+            match = HUNK_HEADER_RE.match(line)
+            new_line = int(match.group(1)) if (match and current_file) else None
+            continue
+        if current_file is None or new_line is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            commentable.setdefault(current_file, set()).add(new_line)
+            new_line += 1
+        elif line.startswith(" "):
+            commentable.setdefault(current_file, set()).add(new_line)
+            new_line += 1
+        # lines starting with "-" have no line on the right side — don't advance
+    return commentable
+
+
+def format_finding(finding, with_location=False):
+    emoji = SEVERITY_EMOJI.get(finding["severity"], "⚪")
+    location = f" `{finding['file']}:{finding['line']}`" if with_location else ""
+    return f"{emoji} **[{finding['severity'].upper()}]{location} {finding['title']}**\n\n{finding['body']}"
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--findings", required=True)
+    parser.add_argument("--diff", required=True)
     parser.add_argument("--repo", required=True)
     parser.add_argument("--pr", required=True, type=int)
     args = parser.parse_args()
 
     with open(args.findings) as f:
-        data = json.load(f)
-
-    findings = data.get("findings", [])
+        findings = json.load(f).get("findings", [])
     if not findings:
         print("No findings — skipping review comment.")
         return
 
-    comments = []
+    with open(args.diff) as f:
+        commentable = parse_commentable_lines(f.read())
+
+    inline_comments, folded = [], []
     for finding in findings:
-        emoji = SEVERITY_EMOJI.get(finding["severity"], "⚪")
-        body = f"{emoji} **[{finding['severity'].upper()}] {finding['title']}**\n\n{finding['body']}"
-        comments.append({"path": finding["file"], "line": finding["line"], "body": body})
+        if finding["line"] in commentable.get(finding["file"], set()):
+            inline_comments.append({"path": finding["file"], "line": finding["line"], "body": format_finding(finding)})
+        else:
+            folded.append(finding)
 
     counts = {"critical": 0, "high": 0, "medium": 0}
     for finding in findings:
@@ -40,12 +82,19 @@ def main():
         summary_lines.append(f"🟠 **{counts['high']} high**")
     if counts["medium"]:
         summary_lines.append(f"🟡 {counts['medium']} medium")
-    review_body = "\n".join(summary_lines)
+
+    if folded:
+        summary_lines.append(
+            "\n### Findings outside the diff\n"
+            "GitHub only allows inline comments on lines visible in the diff, so these are listed here instead:\n"
+        )
+        for finding in folded:
+            summary_lines.append(f"\n{format_finding(finding, with_location=True)}")
 
     event = "REQUEST_CHANGES" if (counts["critical"] or counts["high"]) else "COMMENT"
 
     owner, repo = args.repo.split("/", 1)
-    payload = json.dumps({"body": review_body, "event": event, "comments": comments})
+    payload = json.dumps({"body": "\n".join(summary_lines), "event": event, "comments": inline_comments})
 
     result = subprocess.run(
         ["gh", "api", f"/repos/{owner}/{repo}/pulls/{args.pr}/reviews",
@@ -57,7 +106,7 @@ def main():
         print(result.stderr, file=sys.stderr)
         sys.exit(1)
 
-    print(f"Posted review: {event} with {len(findings)} finding(s).")
+    print(f"Posted review: {event} with {len(inline_comments)} inline, {len(folded)} folded into summary.")
 
     if counts["critical"] or counts["high"]:
         print(f"::error::{counts['critical']} critical, {counts['high']} high severity finding(s) "

--- a/.github/scripts/review_threads.py
+++ b/.github/scripts/review_threads.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Shared GraphQL helper for reading a PR's review threads. REST has no
+concept of thread resolution — only GraphQL exposes `isResolved`."""
+import json, subprocess, sys
+
+QUERY = """
+query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          path
+          line
+          comments(first: 1) {
+            nodes { body author { login } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_review_threads(owner, repo, pr):
+    threads = []
+    after = None
+    while True:
+        args = [
+            "gh", "api", "graphql",
+            "-f", f"query={QUERY}",
+            "-f", f"owner={owner}",
+            "-f", f"repo={repo}",
+            "-F", f"pr={pr}",
+        ]
+        args += ["-f", f"after={after}"] if after else ["-F", "after=null"]
+
+        result = subprocess.run(args, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            sys.exit(1)
+
+        page = json.loads(result.stdout)["data"]["repository"]["pullRequest"]["reviewThreads"]
+        threads.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        after = page["pageInfo"]["endCursor"]
+    return threads
+
+
+def bot_authored(thread):
+    comments = thread["comments"]["nodes"]
+    if not comments:
+        return False
+    author = (comments[0].get("author") or {}).get("login", "")
+    return "github-actions" in author

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -6,8 +6,32 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  ai-review:
+  budget-check:
     if: vars.AI_REVIEW_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      skip: ${{ steps.budget.outputs.skip }}
+    steps:
+      - name: Count today's AI review runs
+        id: budget
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          total=$(gh api "/repos/${{ github.repository }}/actions/workflows/pr-review.yml/runs?created=%3E%3D${today}&per_page=100" --jq '.total_count')
+          prior=$((total - 1)) # exclude this run itself
+          echo "AI review runs today (before this one): $prior"
+          if [ "$prior" -ge 10 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  ai-review:
+    needs: budget-check
+    if: vars.AI_REVIEW_ENABLED == 'true' && needs.budget-check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -43,7 +67,7 @@ jobs:
             --system-prompt-file .github/prompts/pr-review.md \
             --output-format json \
             --json-schema "$(cat .github/prompts/review-schema.json)" \
-            --dangerously-skip-permissions \
+            --tools "" \
             < /tmp/pr.diff \
             | jq '.result | fromjson' > /tmp/review.json
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fail on unresolved critical/high findings from previous runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/check-unresolved.py \
+            --repo ${{ github.repository }} \
+            --pr ${{ github.event.pull_request.number }}
+
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code
 
@@ -30,10 +38,11 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          set -o pipefail
           claude --print \
             --system-prompt-file .github/prompts/pr-review.md \
             --output-format json \
-            --json-schema .github/prompts/review-schema.json \
+            --json-schema "$(cat .github/prompts/review-schema.json)" \
             --dangerously-skip-permissions \
             < /tmp/pr.diff \
             | jq '.result | fromjson' > /tmp/review.json

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,48 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ai-review:
+    if: vars.AI_REVIEW_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Get PR diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
+
+      - name: Run Claude review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude --print \
+            --system-prompt-file .github/prompts/pr-review.md \
+            --output-format json \
+            --json-schema .github/prompts/review-schema.json \
+            --dangerously-skip-permissions \
+            < /tmp/pr.diff \
+            | jq '.result | fromjson' > /tmp/review.json
+
+      - name: Post review comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/post-review.py \
+            --findings /tmp/review.json \
+            --repo ${{ github.repository }} \
+            --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -59,6 +59,8 @@ jobs:
         run: gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
 
       - name: Run Claude review
+        id: claude-review
+        continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -72,6 +74,7 @@ jobs:
             | jq '.result | fromjson' > /tmp/review.json
 
       - name: Post review comments
+        if: steps.claude-review.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -80,3 +83,7 @@ jobs:
             --diff /tmp/pr.diff \
             --repo ${{ github.repository }} \
             --pr ${{ github.event.pull_request.number }}
+
+      - name: Warn if review could not run
+        if: steps.claude-review.outcome != 'success'
+        run: echo "::warning::Claude review call failed (e.g. API/credits issue) — skipped without failing CI."

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -53,5 +53,6 @@ jobs:
         run: |
           python3 .github/scripts/post-review.py \
             --findings /tmp/review.json \
+            --diff /tmp/pr.diff \
             --repo ${{ github.repository }} \
             --pr ${{ github.event.pull_request.number }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${HISCARIES_GITHUB_TOKEN}"
+      }
+    },
+    "postgres": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "${HISCARIES_POSTGRES_URL}"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,69 @@ For full frontend setup, team conventions, and all commands, see
 
 ---
 
+## AI-Assisted Development (Claude Code)
+
+The repo is configured for [Claude Code](https://claude.ai/claude-code) with MCP servers, project skills, and an AI PR review workflow.
+
+### Prerequisites
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+### Environment Variables
+
+Add these to your shell profile (`~/.zshrc` or `~/.bashrc`):
+
+```bash
+# GitHub MCP — Personal Access Token with `repo` scope
+# Create one at: GitHub → Settings → Developer settings → Personal access tokens (classic)
+export HISCARIES_GITHUB_TOKEN="ghp_your_token_here"
+
+# Postgres MCP — local Aspire database connection string
+export HISCARIES_POSTGRES_URL="postgresql://postgres:Hisc4ryDev!2025@localhost:5432/postgres"
+```
+
+Both are read by `.mcp.json` at the repo root. The MCP servers start automatically when you open Claude Code in this directory.
+
+### Aspire DB Static Password (one-time)
+
+The Postgres MCP connects to the Aspire-managed database. Set a fixed password via .NET User Secrets so it is stable across container restarts:
+
+```bash
+cd server/src/Hiscary.AppHost
+dotnet user-secrets set "Parameters:postgres-password" "Hisc4ryDev!2025"
+```
+
+### Available Skills
+
+Open Claude Code in this repo and use these slash commands:
+
+| Skill | Example | What it does |
+|-------|---------|-------------|
+| `/spec` | `/spec issue:42` | Fetches GitHub issue, creates a `design.md` spec in `.claude/specs/` |
+| `/implement` | `/implement issue:42` | Reads the spec, creates a branch, implements all tasks |
+| `/ship` | `/ship` | Commits, pushes, opens a PR with auto-generated description and `ai` label |
+| `/automation-ideas` | `/automation-ideas` | Suggests Claude Code automation opportunities for the codebase |
+| `/security-audit` | `/security-audit` | Runs a security audit against the current changes |
+
+### GitHub Actions — AI PR Review
+
+Every PR to `master` is reviewed by Claude, which posts inline comments for defects only (critical / high / medium — no praise, no style notes).
+
+**One-time setup for maintainers:**
+
+1. **Secret** — repo → Settings → Secrets and variables → Actions → Secrets → New repository secret:
+   - Name: `ANTHROPIC_API_KEY`
+   - Value: your Anthropic API key from [console.anthropic.com](https://console.anthropic.com)
+2. **Variable** — repo → Settings → Secrets and variables → Actions → Variables → New repository variable:
+   - Name: `AI_REVIEW_ENABLED`
+   - Value: `true`
+
+To disable the AI review without a code change, set `AI_REVIEW_ENABLED = false` in the repo variable.
+
+---
+
 🎉 **Thank you for visiting the repository!**
 
 Feel free to contribute or raise any issues to improve the application!

--- a/README.md
+++ b/README.md
@@ -102,20 +102,22 @@ Add these to your shell profile (`~/.zshrc` or `~/.bashrc`):
 # Create one at: GitHub → Settings → Developer settings → Personal access tokens (classic)
 export HISCARIES_GITHUB_TOKEN="ghp_your_token_here"
 
-# Postgres MCP — local Aspire database connection string
-export HISCARIES_POSTGRES_URL="postgresql://postgres:Hisc4ryDev!2025@localhost:5432/postgres"
+# Postgres MCP — must match the password you set in Aspire User Secrets (see below)
+export HISCARIES_POSTGRES_URL="postgresql://postgres:<your-password>@localhost:5432/postgres"
 ```
 
 Both are read by `.mcp.json` at the repo root. The MCP servers start automatically when you open Claude Code in this directory.
 
 ### Aspire DB Static Password (one-time)
 
-The Postgres MCP connects to the Aspire-managed database. Set a fixed password via .NET User Secrets so it is stable across container restarts:
+The Postgres MCP connects to the Aspire-managed database. Pick any strong password, set it in .NET User Secrets, and use the same value in `HISCARIES_POSTGRES_URL` above:
 
 ```bash
 cd server/src/Hiscary.AppHost
-dotnet user-secrets set "Parameters:postgres-password" "Hisc4ryDev!2025"
+dotnet user-secrets set "Parameters:postgres-password" "<your-password>"
 ```
+
+User Secrets are stored in your OS secret store and never committed to the repo.
 
 ### Available Skills
 

--- a/client/README.md
+++ b/client/README.md
@@ -50,6 +50,10 @@ After `npm ci`, Husky is installed via the `prepare` script. Hooks run automatic
 - `pre-commit`: runs `lint-staged`
 - `commit-msg`: validates commit format with Commitlint
 
+**Claude Code hook** — when Claude Code edits any `.ts` file, a PostToolUse hook automatically runs
+`nx lint hiscaries-client --fix`. This keeps AI-generated code lint-compliant without manual
+intervention. No setup required; configured in `.claude/settings.local.json`.
+
 ## Troubleshooting
 
 - If Nx behaves unexpectedly, run `npm run reset`.

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -65,7 +65,7 @@ Pattern per bounded context:
 - ORM: **EF Core** with **PostgreSQL**
 - Local Postgres runs in Docker via Aspire, always on **port 5432**
 - Password is static, stored in .NET User Secrets (never committed): `dotnet user-secrets set "Parameters:postgres-password" "<pass>" --project server/src/Hiscary.AppHost`
-- Local connection string: `postgresql://postgres:Hisc4ryDev!2025@localhost:5432/postgres`
+- Local connection string: `postgresql://postgres:<your-password>@localhost:5432/postgres` (use whatever password you set in User Secrets)
 - Migrations live in `{Ctx}.Persistence.Context` projects
 - Add a migration:
   ```


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-review.yml` — triggers on every PR to `master`, gated by `AI_REVIEW_ENABLED` repo variable
- Adds `.github/prompts/pr-review.md` — strict defect-only system prompt with severity criteria (critical / high / medium) and few-shot examples for .NET/Angular patterns
- Adds `.github/prompts/review-schema.json` — JSON Schema for `--json-schema` flag, guarantees structured output with no prose
- Adds `.github/scripts/post-review.py` — posts a single GitHub PR review with inline comments; `REQUEST_CHANGES` for critical/high, `COMMENT` for medium-only
- Updates `.claude/skills/ship/SKILL.md` — MCP-first PR creation with `gh` fallback, auto-creates `ai` label

## How it works

1. On PR open/push, Claude CLI reads the diff and returns `{ "findings": [...] }` constrained by the JSON schema
2. `post-review.py` maps findings to inline GitHub review comments with severity emoji
3. Set repo variable `AI_REVIEW_ENABLED = true` (Actions → Variables) to enable; flip to `false` to disable instantly

## Required setup

- Add `ANTHROPIC_API_KEY` to repo → Settings → Secrets → Actions

## Test plan

- [ ] Open a test PR with a deliberate bug (e.g. remove `[Authorize]` from a controller)
- [ ] Confirm `AI PR Review` job appears alongside existing CI checks
- [ ] Confirm inline comments appear at correct file + line with severity emoji
- [ ] Confirm `REQUEST_CHANGES` fires for critical/high findings
- [ ] Confirm `COMMENT` (non-blocking) fires for medium-only
- [ ] Confirm clean PR returns no comments

🤖 Generated with [Claude Code](https://claude.ai/claude-code)